### PR TITLE
Consistant fee display

### DIFF
--- a/src/TxMutationParser.php
+++ b/src/TxMutationParser.php
@@ -49,7 +49,6 @@ class TxMutationParser
       }
     }
     unset($v);
-    //dd($balanceChangeExclFeeOnly,$ownBalanceChanges);
 
     /**
      * Get signer from tx public key
@@ -357,6 +356,9 @@ class TxMutationParser
     /**
      * Fallback to default
      * Possibly XRP sent, if so: exclude fee
+     * If fee equals to amount then fallback is zero,
+     *  fee is only primary change and we do not record that,
+     *  this will keep fee display consistant.
      */
     $fallback = $balanceChanges[0];
    
@@ -366,12 +368,10 @@ class TxMutationParser
       \substr($fallback['value'],0,1) === '-' &&
       $fee
     ) {
-     
       $fallback['value'] = BigDecimal::of($fallback['value'])->abs()->isEqualTo( BigDecimal::of($fee)->abs() ) 
-        ? '0' //$fallback['value'] //fee equals to !value
+        ? null //$fallback['value'] //fee equals to !value = zero change
         : (string)BigDecimal::of($fallback['value'])->plus($fee)->stripTrailingZeros();
-        //dd($fallback,BigDecimal::of($fallback['value'])->abs()->isEqualTo( BigDecimal::of($fee)->abs() ));
-      if($fallback['value'] === '0')
+      if($fallback['value'] === null)
         return [];
       return $fallback;
     }

--- a/tests/ATx17Test.php
+++ b/tests/ATx17Test.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace XRPLWin\XRPLOrderbookReader\Tests;
+
+use PHPUnit\Framework\TestCase;
+use XRPLWin\XRPLTxMutatationParser\TxMutationParser;
+
+/***
+ * @see https://github.com/XRPL-Labs/TxMutationParser/blob/main/test/tx1.ts
+ * @see https://hash.xrp.fans/D36265AD359D82BDF056CAFE760F9DFF42BB21C308EC3F68C4DE0D707D2FB6B6/json
+ */
+final class ATx17Test extends TestCase
+{
+    public function testDepositPreauthFeePayer()
+    {
+        $transaction = file_get_contents(__DIR__.'/fixtures/tx17.json');
+        $transaction = \json_decode($transaction);
+        $account = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn";
+        $TxMutationParser = new TxMutationParser($account, $transaction->result);
+        $parsedTransaction = $TxMutationParser->result();
+
+        //Self (own account) must be $account
+        $this->assertEquals($account,$parsedTransaction['self']['account']);
+
+        # Basic info
+
+        //Own account: one balance change
+        $this->assertEquals(1,count($parsedTransaction['self']['balanceChanges']));
+
+        //Transaction type SET
+        $this->assertEquals(TxMutationParser::MUTATIONTYPE_SET,$parsedTransaction['type']);
+
+        $this->assertTrue($parsedTransaction['self']['feePayer']);
+
+        # Event list
+
+        //does not contain `primary` entry
+        $this->assertArrayNotHasKey('primary',$parsedTransaction['eventList']);
+
+        //does not contain `secondary` entry
+        $this->assertArrayNotHasKey('secondary',$parsedTransaction['eventList']);
+       
+
+    }
+}

--- a/tests/Tx16Test.php
+++ b/tests/Tx16Test.php
@@ -24,7 +24,7 @@ final class Tx16Test extends TestCase
 
         # Basic info
 
-        //Own account: two balance changes
+        //Own account: three balance changes
         $this->assertEquals(3,count($parsedTransaction['self']['balanceChanges']));
 
         //Transaction type TRADE

--- a/tests/Tx17Test.php
+++ b/tests/Tx17Test.php
@@ -9,7 +9,7 @@ use XRPLWin\XRPLTxMutatationParser\TxMutationParser;
  * @see https://github.com/XRPL-Labs/TxMutationParser/blob/main/test/tx1.ts
  * @see https://hash.xrp.fans/D36265AD359D82BDF056CAFE760F9DFF42BB21C308EC3F68C4DE0D707D2FB6B6/json
  */
-final class ATx17Test extends TestCase
+final class Tx17Test extends TestCase
 {
     public function testDepositPreauthFeePayer()
     {
@@ -39,7 +39,16 @@ final class ATx17Test extends TestCase
 
         //does not contain `secondary` entry
         $this->assertArrayNotHasKey('secondary',$parsedTransaction['eventList']);
-       
+
+        # Event flow
+        //does not contain `start` entry
+        $this->assertArrayNotHasKey('start',$parsedTransaction['eventFlow']);
+
+        //does not contain `intermediate` entry
+        $this->assertArrayNotHasKey('intermediate',$parsedTransaction['eventFlow']);
+
+        //does not contain `end` entry
+        $this->assertArrayNotHasKey('end',$parsedTransaction['eventFlow']);
 
     }
 }

--- a/tests/Tx5Test.php
+++ b/tests/Tx5Test.php
@@ -18,7 +18,7 @@ final class Tx5Test extends TestCase
         $account = "rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ";
         $TxMutationParser = new TxMutationParser($account, $transaction->result);
         $parsedTransaction = $TxMutationParser->result();
-       
+       //dd( $parsedTransaction);
 
         //Self (own account) must be $account
         $this->assertEquals($account,$parsedTransaction['self']['account']);
@@ -35,34 +35,18 @@ final class Tx5Test extends TestCase
 
         # Event list
 
-        //contains (correct) `primary` entry
-        $this->assertArrayHasKey('primary',$parsedTransaction['eventList']);
-        $this->assertEquals([
-            'currency' => 'XRP',
-            'value' => '-0.000012'
-        ],$parsedTransaction['eventList']['primary']);
-
+        //does not contain `primary` entry
+        $this->assertArrayNotHasKey('primary',$parsedTransaction['eventList']);
 
         //does not contain `secondary` entry
         $this->assertArrayNotHasKey('secondary',$parsedTransaction['eventList']);
-        
 
         # Event flow
-
         //does not contain `start` entry
         $this->assertArrayNotHasKey('start',$parsedTransaction['eventFlow']);
 
-        //contains (correct) `intermediate` entry
-        $this->assertArrayHasKey('intermediate',$parsedTransaction['eventFlow']);
-        $this->assertEquals([
-            'account' => $account,
-            'mutations' => [
-                'out' => [
-                    'currency' => "XRP",
-                    'value' => "-0.000012",
-                ]
-            ]
-        ],$parsedTransaction['eventFlow']['intermediate']);
+        //does not contain `intermediate` entry
+        $this->assertArrayNotHasKey('intermediate',$parsedTransaction['eventFlow']);
 
         //does not contain `end` entry
         $this->assertArrayNotHasKey('end',$parsedTransaction['eventFlow']);

--- a/tests/fixtures/tx17.json
+++ b/tests/fixtures/tx17.json
@@ -1,0 +1,76 @@
+{
+    "id": 1,
+    "result": 
+{
+    "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+    "Authorize": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+    "Fee": "10",
+    "Flags": 2147483648,
+    "LastLedgerSequence": 61965405,
+    "Sequence": 383,
+    "SigningPubKey": "03CE5C5949DEBBBB5E6D8FA54AC3FA8A3ED4EE1C3E9617571840F9349DE7AEF329",
+    "TransactionType": "DepositPreauth",
+    "TxnSignature": "304402206464885794C92713D15141B8C68CD020E5EE0BADB7CA7293CB073F02594BEB6F02205FC46EF82613DB5F2AC583C854B9F3C5FAE223E9C7056CB1625260DD3E0718AC",
+    "date": 668133130,
+    "hash": "CB1BF910C93D050254C049E9003DA1A265C107E0C8DE4A7CFF55FADFD39D5656",
+    "inLedger": 61965405,
+    "ledger_index": 61965405,
+    "meta": {
+        "AffectedNodes": [
+            {
+                "ModifiedNode": {
+                    "FinalFields": {
+                        "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                        "AccountTxnID": "CB1BF910C93D050254C049E9003DA1A265C107E0C8DE4A7CFF55FADFD39D5656",
+                        "Balance": "424021959",
+                        "Domain": "6D64756F31332E636F6D",
+                        "EmailHash": "98B4375E1D753E5B91627516F6D70977",
+                        "Flags": 9568256,
+                        "MessageKey": "0000000000000000000000070000000300",
+                        "OwnerCount": 11,
+                        "RegularKey": "rD9iJmieYHn8jTtPjwwkW2Wm9sVDvPXLoJ",
+                        "Sequence": 384,
+                        "TransferRate": 4294967295
+                    },
+                    "LedgerEntryType": "AccountRoot",
+                    "LedgerIndex": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+                    "PreviousFields": {
+                        "AccountTxnID": "711C4F606C63076137FAE90ADC36379D7066CF551E96DA6FE2BDAB5ECBFACF2B",
+                        "Balance": "424021969",
+                        "OwnerCount": 10,
+                        "Sequence": 383
+                    },
+                    "PreviousTxnID": "711C4F606C63076137FAE90ADC36379D7066CF551E96DA6FE2BDAB5ECBFACF2B",
+                    "PreviousTxnLgrSeq": 61965340
+                }
+            },
+            {
+                "ModifiedNode": {
+                    "FinalFields": {
+                        "Flags": 0,
+                        "Owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                        "RootIndex": "3B9C0CE77FCE7BCEE1A68F1E26AC467AF326239D0D816CE705E4A0E2DAD03F6D"
+                    },
+                    "LedgerEntryType": "DirectoryNode",
+                    "LedgerIndex": "3B9C0CE77FCE7BCEE1A68F1E26AC467AF326239D0D816CE705E4A0E2DAD03F6D"
+                }
+            },
+            {
+                "CreatedNode": {
+                    "LedgerEntryType": "DepositPreauth",
+                    "LedgerIndex": "A43898B685C450DE8E194B24D9D54E62530536A770CCB311BFEE15A27381ABB2",
+                    "NewFields": {
+                        "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                        "Authorize": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX"
+                    }
+                }
+            }
+        ],
+        "TransactionIndex": 59,
+        "TransactionResult": "tesSUCCESS"
+    },
+    "validated": true
+},
+"status": "success",
+"type": "response"
+}


### PR DESCRIPTION
When initiator of transaction pays ONLY fee eg in case of TrustSet primary change is not anymore displayed since no primary change is created when excluding Fee from primary change. This case is true when there was XRP primary balance, and fee in that case was excluded from primary.

Sample transaction 77F965D99CDE91E5B7652EB4406B107C7BDE59A51EE14EB7549813F633296DF1